### PR TITLE
Add a hacky implementation of helm extension to jsonnet

### DIFF
--- a/apps/podinfo-helm/_namespace.jsonnet
+++ b/apps/podinfo-helm/_namespace.jsonnet
@@ -1,0 +1,7 @@
+local namespace = import 'lib/namespace.libsonnet';
+
+
+function(ctx) std.flattenArrays([
+  namespace('podinfo-helm'),
+  std.native('helm')('oci://ghcr.io/stefanprodan/charts/podinfo', std.manifestJsonEx({ namespace: 'podinfo-helm' }, ' ')),
+])

--- a/clusters/envs/base.libsonnet
+++ b/clusters/envs/base.libsonnet
@@ -2,5 +2,6 @@
   Namespaces: [
     // TODO: import or some other compile time check?
     'podinfo',
+    'podinfo-helm',
   ],
 }

--- a/compile.py
+++ b/compile.py
@@ -15,6 +15,7 @@ def run_jsonnet(cmd):
     p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
+        print ('stdout', stdout)
         raise Exception("jsonnet error: %s" % stderr)
     return stdout
 
@@ -40,7 +41,8 @@ def compile_cluster(cluster):
         fpath = os.path.join('./apps', namespace, '_namespace.jsonnet')
         if not os.path.exists(fpath):
             continue
-        cmd = ["jsonnet", fpath, "-J", ".", "-y", '--tla-code-file', 'ctx='+cluster_output]
+        #cmd = ["jsonnet", fpath, "-J", ".", "-y", '--tla-code-file', 'ctx='+cluster_output]
+        cmd = ["./jsonnet-extended.py", fpath, "-J", ".", "-y", '--tla-code-file', 'ctx='+cluster_output]
         stdout = run_jsonnet(cmd)
         # if there was no output, we'll skip this (as its not wanted in this cluster)
         if not stdout.strip():

--- a/compile.py
+++ b/compile.py
@@ -15,7 +15,6 @@ def run_jsonnet(cmd):
     p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
-        print ('stdout', stdout)
         raise Exception("jsonnet error: %s" % stderr)
     return stdout
 

--- a/jsonnet-extended.py
+++ b/jsonnet-extended.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import shlex
+from subprocess import Popen, PIPE
+
+import json
+import _jsonnet
+import yaml
+
+
+def run_cmd(cmd):
+    p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+        raise Exception("cmd error: %s" % stderr)
+    return stdout
+
+parser = argparse.ArgumentParser(
+    prog='jsonnet-extend',
+    description='extend jsonnet with helm')
+
+parser.add_argument('filename')           
+parser.add_argument('-J', '--jpath')      
+parser.add_argument('-y', '--yaml-stream', action='store_true')
+parser.add_argument('--tla-code-file')
+args = parser.parse_args()
+
+
+# TODO: better?
+# this inlines a method into jsonnet which will shell out to `helm template` with the same tla code file data??
+def helm(chart, values):
+    values = json.loads(values)
+    
+    app_values = ','.join([ str(k)+'='+json.dumps(v) for k, v in values.items() ])
+    cmd = ["helm", "template", chart, "--set-json='"+app_values+"'" ]
+    # TODO: figure out some weird escaping...
+    cmd = shlex.split(' '.join(cmd))
+    stdout = run_cmd(cmd)
+
+    out_objs = []
+    objs = yaml.safe_load_all(stdout)
+    for o in objs:
+        # TODO: remove -- this is a hack around some weird helm-ness
+        # right now if the chart is remote then helm prints out a pulled/digest block -- which is valid yaml but not valid manifests
+        if sorted(o.keys()) == ['Digest', 'Pulled', ]:
+            continue
+        # TODO: better?
+        # upstream `helm template` doesn't honor the `--namespace` flag (https://github.com/helm/helm/issues/3553)
+        # and as such most helm charts don't handle it either. so for now we are cheating by adding this in here
+        if 'namespace' in values:
+            if 'metadata' in o and 'namespace' not in o['metadata']:
+                o['metadata']['namespace'] = values['namespace']
+        out_objs.append(o)
+    
+    
+    return out_objs
+
+native_callbacks = {
+    'helm': (('chart', 'values'), helm),
+}
+
+tla_codes = {}
+if args.tla_code_file:
+    k, v = args.tla_code_file.split('=', 1)
+    tla_codes = {k: open(v).read()}
+
+ret = _jsonnet.evaluate_file(
+    args.filename,
+    jpathdir=args.jpath,
+    
+    tla_codes=tla_codes,
+    native_callbacks=native_callbacks,
+)
+
+ret = json.loads(ret)
+
+if args.yaml_stream:
+    # replicate the same output stream
+    for obj in ret:
+        print('---\n'+json.dumps(obj, indent="   "), file=sys.stdout)
+    print ('...', file=sys.stdout)
+else:
+    print ('done')
+    print (ret)
+    print ('done')

--- a/releases/devcluster/cluster.json
+++ b/releases/devcluster/cluster.json
@@ -2,6 +2,7 @@
    "Environment": "dev",
    "Name": "devcluster",
    "Namespaces": [
-      "podinfo"
+      "podinfo",
+      "podinfo-helm"
    ]
 }

--- a/releases/devcluster/release/kustomization.yaml
+++ b/releases/devcluster/release/kustomization.yaml
@@ -1,4 +1,5 @@
 apiversion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- podinfo-helm/_namespace.yaml
 - podinfo/_namespace.yaml

--- a/releases/devcluster/release/podinfo-helm/_namespace.yaml
+++ b/releases/devcluster/release/podinfo-helm/_namespace.yaml
@@ -1,0 +1,326 @@
+---
+{
+   "apiVersion": "v1",
+   "kind": "Namespace",
+   "metadata": {
+      "labels": {
+         "name": "podinfo-helm"
+      },
+      "name": "podinfo-helm"
+   }
+}
+---
+{
+   "apiVersion": "rbac.authorization.k8s.io/v1",
+   "kind": "RoleBinding",
+   "metadata": {
+      "labels": {
+         "addonmanager.kubernetes.io/mode": "EnsureExists",
+         "kubernetes.io/cluster-service": "true"
+      },
+      "name": "k8s-users",
+      "namespace": "podinfo-helm"
+   },
+   "roleRef": {
+      "apiGroup": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "admin"
+   },
+   "subjects": [
+      {
+         "apiGroup": "rbac.authorization.k8s.io",
+         "kind": "Group",
+         "name": "automatedoperations:k8s-users"
+      }
+   ]
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Service",
+   "metadata": {
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "ports": [
+         {
+            "name": "http",
+            "port": 9898,
+            "protocol": "TCP",
+            "targetPort": "http"
+         },
+         {
+            "name": "grpc",
+            "port": 9999,
+            "protocol": "TCP",
+            "targetPort": "grpc"
+         }
+      ],
+      "selector": {
+         "app.kubernetes.io/name": "release-name-podinfo"
+      },
+      "type": "ClusterIP"
+   }
+}
+---
+{
+   "apiVersion": "apps/v1",
+   "kind": "Deployment",
+   "metadata": {
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "replicas": 1,
+      "selector": {
+         "matchLabels": {
+            "app.kubernetes.io/name": "release-name-podinfo"
+         }
+      },
+      "strategy": {
+         "rollingUpdate": {
+            "maxUnavailable": 1
+         },
+         "type": "RollingUpdate"
+      },
+      "template": {
+         "metadata": {
+            "annotations": {
+               "prometheus.io/port": "9898",
+               "prometheus.io/scrape": "true"
+            },
+            "labels": {
+               "app.kubernetes.io/name": "release-name-podinfo"
+            }
+         },
+         "spec": {
+            "containers": [
+               {
+                  "command": [
+                     "./podinfo",
+                     "--port=9898",
+                     "--cert-path=/data/cert",
+                     "--port-metrics=9797",
+                     "--grpc-port=9999",
+                     "--grpc-service-name=podinfo",
+                     "--level=info",
+                     "--random-delay=false",
+                     "--random-error=false"
+                  ],
+                  "env": [
+                     {
+                        "name": "PODINFO_UI_COLOR",
+                        "value": "#34577c"
+                     }
+                  ],
+                  "image": "ghcr.io/stefanprodan/podinfo:6.3.5",
+                  "imagePullPolicy": "IfNotPresent",
+                  "livenessProbe": {
+                     "exec": {
+                        "command": [
+                           "podcli",
+                           "check",
+                           "http",
+                           "localhost:9898/healthz"
+                        ]
+                     },
+                     "failureThreshold": 3,
+                     "initialDelaySeconds": 1,
+                     "periodSeconds": 10,
+                     "successThreshold": 1,
+                     "timeoutSeconds": 5
+                  },
+                  "name": "podinfo",
+                  "ports": [
+                     {
+                        "containerPort": 9898,
+                        "name": "http",
+                        "protocol": "TCP"
+                     },
+                     {
+                        "containerPort": 9797,
+                        "name": "http-metrics",
+                        "protocol": "TCP"
+                     },
+                     {
+                        "containerPort": 9999,
+                        "name": "grpc",
+                        "protocol": "TCP"
+                     }
+                  ],
+                  "readinessProbe": {
+                     "exec": {
+                        "command": [
+                           "podcli",
+                           "check",
+                           "http",
+                           "localhost:9898/readyz"
+                        ]
+                     },
+                     "failureThreshold": 3,
+                     "initialDelaySeconds": 1,
+                     "periodSeconds": 10,
+                     "successThreshold": 1,
+                     "timeoutSeconds": 5
+                  },
+                  "resources": {
+                     "limits": null,
+                     "requests": {
+                        "cpu": "1m",
+                        "memory": "16Mi"
+                     }
+                  },
+                  "volumeMounts": [
+                     {
+                        "mountPath": "/data",
+                        "name": "data"
+                     }
+                  ]
+               }
+            ],
+            "terminationGracePeriodSeconds": 30,
+            "volumes": [
+               {
+                  "emptyDir": {},
+                  "name": "data"
+               }
+            ]
+         }
+      }
+   }
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "annotations": {
+         "appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
+         "helm.sh/hook": "test-success",
+         "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+         "linkerd.io/inject": "disabled",
+         "sidecar.istio.io/inject": "false"
+      },
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo-grpc-test-ema30",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "containers": [
+         {
+            "args": [
+               "-addr=release-name-podinfo.default:9999"
+            ],
+            "command": [
+               "grpc_health_probe"
+            ],
+            "image": "stefanprodan/grpc_health_probe:v0.3.0",
+            "name": "grpc-health-probe"
+         }
+      ],
+      "restartPolicy": "Never"
+   }
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "annotations": {
+         "appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
+         "helm.sh/hook": "test-success",
+         "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+         "linkerd.io/inject": "disabled",
+         "sidecar.istio.io/inject": "false"
+      },
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo-jwt-test-2cqse",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "containers": [
+         {
+            "command": [
+               "sh",
+               "-c",
+               "TOKEN=$(curl -sd 'test' ${PODINFO_SVC}/token | jq -r .token) &&\ncurl -sH \"Authorization: Bearer ${TOKEN}\" ${PODINFO_SVC}/token/validate | grep test\n"
+            ],
+            "env": [
+               {
+                  "name": "PODINFO_SVC",
+                  "value": "release-name-podinfo.default:9898"
+               }
+            ],
+            "image": "giantswarm/tiny-tools",
+            "name": "tools"
+         }
+      ],
+      "restartPolicy": "Never"
+   }
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "annotations": {
+         "appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
+         "helm.sh/hook": "test-success",
+         "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+         "linkerd.io/inject": "disabled",
+         "sidecar.istio.io/inject": "false"
+      },
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo-service-test-uiesc",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "containers": [
+         {
+            "command": [
+               "sh",
+               "-c",
+               "curl -s ${PODINFO_SVC}/api/info | grep version\n"
+            ],
+            "env": [
+               {
+                  "name": "PODINFO_SVC",
+                  "value": "release-name-podinfo.default:9898"
+               }
+            ],
+            "image": "curlimages/curl:7.69.0",
+            "name": "curl"
+         }
+      ],
+      "restartPolicy": "Never"
+   }
+}
+...

--- a/releases/prodcluster/cluster.json
+++ b/releases/prodcluster/cluster.json
@@ -2,6 +2,7 @@
    "Environment": "prod",
    "Name": "prodcluster",
    "Namespaces": [
-      "podinfo"
+      "podinfo",
+      "podinfo-helm"
    ]
 }

--- a/releases/prodcluster/release/kustomization.yaml
+++ b/releases/prodcluster/release/kustomization.yaml
@@ -1,4 +1,5 @@
 apiversion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- podinfo-helm/_namespace.yaml
 - podinfo/_namespace.yaml

--- a/releases/prodcluster/release/podinfo-helm/_namespace.yaml
+++ b/releases/prodcluster/release/podinfo-helm/_namespace.yaml
@@ -1,0 +1,326 @@
+---
+{
+   "apiVersion": "v1",
+   "kind": "Namespace",
+   "metadata": {
+      "labels": {
+         "name": "podinfo-helm"
+      },
+      "name": "podinfo-helm"
+   }
+}
+---
+{
+   "apiVersion": "rbac.authorization.k8s.io/v1",
+   "kind": "RoleBinding",
+   "metadata": {
+      "labels": {
+         "addonmanager.kubernetes.io/mode": "EnsureExists",
+         "kubernetes.io/cluster-service": "true"
+      },
+      "name": "k8s-users",
+      "namespace": "podinfo-helm"
+   },
+   "roleRef": {
+      "apiGroup": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "admin"
+   },
+   "subjects": [
+      {
+         "apiGroup": "rbac.authorization.k8s.io",
+         "kind": "Group",
+         "name": "automatedoperations:k8s-users"
+      }
+   ]
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Service",
+   "metadata": {
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "ports": [
+         {
+            "name": "http",
+            "port": 9898,
+            "protocol": "TCP",
+            "targetPort": "http"
+         },
+         {
+            "name": "grpc",
+            "port": 9999,
+            "protocol": "TCP",
+            "targetPort": "grpc"
+         }
+      ],
+      "selector": {
+         "app.kubernetes.io/name": "release-name-podinfo"
+      },
+      "type": "ClusterIP"
+   }
+}
+---
+{
+   "apiVersion": "apps/v1",
+   "kind": "Deployment",
+   "metadata": {
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "replicas": 1,
+      "selector": {
+         "matchLabels": {
+            "app.kubernetes.io/name": "release-name-podinfo"
+         }
+      },
+      "strategy": {
+         "rollingUpdate": {
+            "maxUnavailable": 1
+         },
+         "type": "RollingUpdate"
+      },
+      "template": {
+         "metadata": {
+            "annotations": {
+               "prometheus.io/port": "9898",
+               "prometheus.io/scrape": "true"
+            },
+            "labels": {
+               "app.kubernetes.io/name": "release-name-podinfo"
+            }
+         },
+         "spec": {
+            "containers": [
+               {
+                  "command": [
+                     "./podinfo",
+                     "--port=9898",
+                     "--cert-path=/data/cert",
+                     "--port-metrics=9797",
+                     "--grpc-port=9999",
+                     "--grpc-service-name=podinfo",
+                     "--level=info",
+                     "--random-delay=false",
+                     "--random-error=false"
+                  ],
+                  "env": [
+                     {
+                        "name": "PODINFO_UI_COLOR",
+                        "value": "#34577c"
+                     }
+                  ],
+                  "image": "ghcr.io/stefanprodan/podinfo:6.3.5",
+                  "imagePullPolicy": "IfNotPresent",
+                  "livenessProbe": {
+                     "exec": {
+                        "command": [
+                           "podcli",
+                           "check",
+                           "http",
+                           "localhost:9898/healthz"
+                        ]
+                     },
+                     "failureThreshold": 3,
+                     "initialDelaySeconds": 1,
+                     "periodSeconds": 10,
+                     "successThreshold": 1,
+                     "timeoutSeconds": 5
+                  },
+                  "name": "podinfo",
+                  "ports": [
+                     {
+                        "containerPort": 9898,
+                        "name": "http",
+                        "protocol": "TCP"
+                     },
+                     {
+                        "containerPort": 9797,
+                        "name": "http-metrics",
+                        "protocol": "TCP"
+                     },
+                     {
+                        "containerPort": 9999,
+                        "name": "grpc",
+                        "protocol": "TCP"
+                     }
+                  ],
+                  "readinessProbe": {
+                     "exec": {
+                        "command": [
+                           "podcli",
+                           "check",
+                           "http",
+                           "localhost:9898/readyz"
+                        ]
+                     },
+                     "failureThreshold": 3,
+                     "initialDelaySeconds": 1,
+                     "periodSeconds": 10,
+                     "successThreshold": 1,
+                     "timeoutSeconds": 5
+                  },
+                  "resources": {
+                     "limits": null,
+                     "requests": {
+                        "cpu": "1m",
+                        "memory": "16Mi"
+                     }
+                  },
+                  "volumeMounts": [
+                     {
+                        "mountPath": "/data",
+                        "name": "data"
+                     }
+                  ]
+               }
+            ],
+            "terminationGracePeriodSeconds": 30,
+            "volumes": [
+               {
+                  "emptyDir": {},
+                  "name": "data"
+               }
+            ]
+         }
+      }
+   }
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "annotations": {
+         "appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
+         "helm.sh/hook": "test-success",
+         "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+         "linkerd.io/inject": "disabled",
+         "sidecar.istio.io/inject": "false"
+      },
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo-grpc-test-zt63m",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "containers": [
+         {
+            "args": [
+               "-addr=release-name-podinfo.default:9999"
+            ],
+            "command": [
+               "grpc_health_probe"
+            ],
+            "image": "stefanprodan/grpc_health_probe:v0.3.0",
+            "name": "grpc-health-probe"
+         }
+      ],
+      "restartPolicy": "Never"
+   }
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "annotations": {
+         "appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
+         "helm.sh/hook": "test-success",
+         "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+         "linkerd.io/inject": "disabled",
+         "sidecar.istio.io/inject": "false"
+      },
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo-jwt-test-xv5mt",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "containers": [
+         {
+            "command": [
+               "sh",
+               "-c",
+               "TOKEN=$(curl -sd 'test' ${PODINFO_SVC}/token | jq -r .token) &&\ncurl -sH \"Authorization: Bearer ${TOKEN}\" ${PODINFO_SVC}/token/validate | grep test\n"
+            ],
+            "env": [
+               {
+                  "name": "PODINFO_SVC",
+                  "value": "release-name-podinfo.default:9898"
+               }
+            ],
+            "image": "giantswarm/tiny-tools",
+            "name": "tools"
+         }
+      ],
+      "restartPolicy": "Never"
+   }
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "annotations": {
+         "appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
+         "helm.sh/hook": "test-success",
+         "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+         "linkerd.io/inject": "disabled",
+         "sidecar.istio.io/inject": "false"
+      },
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo-service-test-uk29i",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "containers": [
+         {
+            "command": [
+               "sh",
+               "-c",
+               "curl -s ${PODINFO_SVC}/api/info | grep version\n"
+            ],
+            "env": [
+               {
+                  "name": "PODINFO_SVC",
+                  "value": "release-name-podinfo.default:9898"
+               }
+            ],
+            "image": "curlimages/curl:7.69.0",
+            "name": "curl"
+         }
+      ],
+      "restartPolicy": "Never"
+   }
+}
+...

--- a/releases/stagecluster/cluster.json
+++ b/releases/stagecluster/cluster.json
@@ -2,6 +2,7 @@
    "Environment": "stage",
    "Name": "stagecluster",
    "Namespaces": [
-      "podinfo"
+      "podinfo",
+      "podinfo-helm"
    ]
 }

--- a/releases/stagecluster/release/kustomization.yaml
+++ b/releases/stagecluster/release/kustomization.yaml
@@ -1,4 +1,5 @@
 apiversion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- podinfo-helm/_namespace.yaml
 - podinfo/_namespace.yaml

--- a/releases/stagecluster/release/podinfo-helm/_namespace.yaml
+++ b/releases/stagecluster/release/podinfo-helm/_namespace.yaml
@@ -1,0 +1,326 @@
+---
+{
+   "apiVersion": "v1",
+   "kind": "Namespace",
+   "metadata": {
+      "labels": {
+         "name": "podinfo-helm"
+      },
+      "name": "podinfo-helm"
+   }
+}
+---
+{
+   "apiVersion": "rbac.authorization.k8s.io/v1",
+   "kind": "RoleBinding",
+   "metadata": {
+      "labels": {
+         "addonmanager.kubernetes.io/mode": "EnsureExists",
+         "kubernetes.io/cluster-service": "true"
+      },
+      "name": "k8s-users",
+      "namespace": "podinfo-helm"
+   },
+   "roleRef": {
+      "apiGroup": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "admin"
+   },
+   "subjects": [
+      {
+         "apiGroup": "rbac.authorization.k8s.io",
+         "kind": "Group",
+         "name": "automatedoperations:k8s-users"
+      }
+   ]
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Service",
+   "metadata": {
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "ports": [
+         {
+            "name": "http",
+            "port": 9898,
+            "protocol": "TCP",
+            "targetPort": "http"
+         },
+         {
+            "name": "grpc",
+            "port": 9999,
+            "protocol": "TCP",
+            "targetPort": "grpc"
+         }
+      ],
+      "selector": {
+         "app.kubernetes.io/name": "release-name-podinfo"
+      },
+      "type": "ClusterIP"
+   }
+}
+---
+{
+   "apiVersion": "apps/v1",
+   "kind": "Deployment",
+   "metadata": {
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "replicas": 1,
+      "selector": {
+         "matchLabels": {
+            "app.kubernetes.io/name": "release-name-podinfo"
+         }
+      },
+      "strategy": {
+         "rollingUpdate": {
+            "maxUnavailable": 1
+         },
+         "type": "RollingUpdate"
+      },
+      "template": {
+         "metadata": {
+            "annotations": {
+               "prometheus.io/port": "9898",
+               "prometheus.io/scrape": "true"
+            },
+            "labels": {
+               "app.kubernetes.io/name": "release-name-podinfo"
+            }
+         },
+         "spec": {
+            "containers": [
+               {
+                  "command": [
+                     "./podinfo",
+                     "--port=9898",
+                     "--cert-path=/data/cert",
+                     "--port-metrics=9797",
+                     "--grpc-port=9999",
+                     "--grpc-service-name=podinfo",
+                     "--level=info",
+                     "--random-delay=false",
+                     "--random-error=false"
+                  ],
+                  "env": [
+                     {
+                        "name": "PODINFO_UI_COLOR",
+                        "value": "#34577c"
+                     }
+                  ],
+                  "image": "ghcr.io/stefanprodan/podinfo:6.3.5",
+                  "imagePullPolicy": "IfNotPresent",
+                  "livenessProbe": {
+                     "exec": {
+                        "command": [
+                           "podcli",
+                           "check",
+                           "http",
+                           "localhost:9898/healthz"
+                        ]
+                     },
+                     "failureThreshold": 3,
+                     "initialDelaySeconds": 1,
+                     "periodSeconds": 10,
+                     "successThreshold": 1,
+                     "timeoutSeconds": 5
+                  },
+                  "name": "podinfo",
+                  "ports": [
+                     {
+                        "containerPort": 9898,
+                        "name": "http",
+                        "protocol": "TCP"
+                     },
+                     {
+                        "containerPort": 9797,
+                        "name": "http-metrics",
+                        "protocol": "TCP"
+                     },
+                     {
+                        "containerPort": 9999,
+                        "name": "grpc",
+                        "protocol": "TCP"
+                     }
+                  ],
+                  "readinessProbe": {
+                     "exec": {
+                        "command": [
+                           "podcli",
+                           "check",
+                           "http",
+                           "localhost:9898/readyz"
+                        ]
+                     },
+                     "failureThreshold": 3,
+                     "initialDelaySeconds": 1,
+                     "periodSeconds": 10,
+                     "successThreshold": 1,
+                     "timeoutSeconds": 5
+                  },
+                  "resources": {
+                     "limits": null,
+                     "requests": {
+                        "cpu": "1m",
+                        "memory": "16Mi"
+                     }
+                  },
+                  "volumeMounts": [
+                     {
+                        "mountPath": "/data",
+                        "name": "data"
+                     }
+                  ]
+               }
+            ],
+            "terminationGracePeriodSeconds": 30,
+            "volumes": [
+               {
+                  "emptyDir": {},
+                  "name": "data"
+               }
+            ]
+         }
+      }
+   }
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "annotations": {
+         "appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
+         "helm.sh/hook": "test-success",
+         "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+         "linkerd.io/inject": "disabled",
+         "sidecar.istio.io/inject": "false"
+      },
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo-grpc-test-z8hsi",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "containers": [
+         {
+            "args": [
+               "-addr=release-name-podinfo.default:9999"
+            ],
+            "command": [
+               "grpc_health_probe"
+            ],
+            "image": "stefanprodan/grpc_health_probe:v0.3.0",
+            "name": "grpc-health-probe"
+         }
+      ],
+      "restartPolicy": "Never"
+   }
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "annotations": {
+         "appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
+         "helm.sh/hook": "test-success",
+         "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+         "linkerd.io/inject": "disabled",
+         "sidecar.istio.io/inject": "false"
+      },
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo-jwt-test-gtgt4",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "containers": [
+         {
+            "command": [
+               "sh",
+               "-c",
+               "TOKEN=$(curl -sd 'test' ${PODINFO_SVC}/token | jq -r .token) &&\ncurl -sH \"Authorization: Bearer ${TOKEN}\" ${PODINFO_SVC}/token/validate | grep test\n"
+            ],
+            "env": [
+               {
+                  "name": "PODINFO_SVC",
+                  "value": "release-name-podinfo.default:9898"
+               }
+            ],
+            "image": "giantswarm/tiny-tools",
+            "name": "tools"
+         }
+      ],
+      "restartPolicy": "Never"
+   }
+}
+---
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "annotations": {
+         "appmesh.k8s.aws/sidecarInjectorWebhook": "disabled",
+         "helm.sh/hook": "test-success",
+         "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+         "linkerd.io/inject": "disabled",
+         "sidecar.istio.io/inject": "false"
+      },
+      "labels": {
+         "app.kubernetes.io/managed-by": "Helm",
+         "app.kubernetes.io/name": "release-name-podinfo",
+         "app.kubernetes.io/version": "6.3.5",
+         "helm.sh/chart": "podinfo-6.3.5"
+      },
+      "name": "release-name-podinfo-service-test-zsqxu",
+      "namespace": "podinfo-helm"
+   },
+   "spec": {
+      "containers": [
+         {
+            "command": [
+               "sh",
+               "-c",
+               "curl -s ${PODINFO_SVC}/api/info | grep version\n"
+            ],
+            "env": [
+               {
+                  "name": "PODINFO_SVC",
+                  "value": "release-name-podinfo.default:9898"
+               }
+            ],
+            "image": "curlimages/curl:7.69.0",
+            "name": "curl"
+         }
+      ],
+      "restartPolicy": "Never"
+   }
+}
+...


### PR DESCRIPTION
Unfortunately helm requires shelling out -- which jsonnet doesn't quite do natively. We can cheat this in by using the `std.native` function (and wrapping in some hack to shell out). This is *similar* to what tanka does (although they embed the whole thing into a new binary).

The only alternative I can think of here is to do a mult-stage build; but I think with some cleaning up this might be a viable option (as it still allows you to override options post-helm -- which is nice-to-have.

TODO: 
- [x] Better namespace override: I did some reading and it is actually valid for a namespace to be defined on most objects (as its part of the V1ObjectMetdatada) -- so the hack that is in place generates valid k8s manifests. Alternatively this would require some integration into the schema/openapi to see if the object has this field.
- [ ] 