### PR TITLE
Add example usage of patch method.

### DIFF
--- a/apps/podinfo-helm/_namespace.jsonnet
+++ b/apps/podinfo-helm/_namespace.jsonnet
@@ -1,18 +1,29 @@
 local helm = import 'lib/helm.libsonnet';
 local namespace = import 'lib/namespace.libsonnet';
 
+local patch = import 'lib/patch.libsonnet';
+
 
 function(ctx) std.flattenArrays([
   namespace('podinfo-helm'),
-  helm.template(
-    'podinfo-helm',
-    'oci://ghcr.io/stefanprodan/charts/podinfo',
-    '6.3.5',
-    {
+  patch.patchArray(
+    helm.template('podinfo-helm', 'oci://ghcr.io/stefanprodan/charts/podinfo', '6.3.5', {
       logLevel: 'debug',
       podAnnotations: {
         environment: ctx.Environment,
       },
-    }
+    }),
+    {
+      metadata: {
+        namespace: 'podinfo-helm',
+      },
+    },
+    {
+      metadata: {
+        labels: {
+          foo: 'bar',
+        },
+      },
+    },
   ),
 ])

--- a/releases/devcluster/release/podinfo-helm/_namespace.yaml
+++ b/releases/devcluster/release/podinfo-helm/_namespace.yaml
@@ -43,6 +43,7 @@
          "app.kubernetes.io/managed-by": "Helm",
          "app.kubernetes.io/name": "release-name-podinfo",
          "app.kubernetes.io/version": "6.3.5",
+         "foo": "bar",
          "helm.sh/chart": "podinfo-6.3.5"
       },
       "name": "release-name-podinfo",
@@ -78,6 +79,7 @@
          "app.kubernetes.io/managed-by": "Helm",
          "app.kubernetes.io/name": "release-name-podinfo",
          "app.kubernetes.io/version": "6.3.5",
+         "foo": "bar",
          "helm.sh/chart": "podinfo-6.3.5"
       },
       "name": "release-name-podinfo",

--- a/releases/prodcluster/release/podinfo-helm/_namespace.yaml
+++ b/releases/prodcluster/release/podinfo-helm/_namespace.yaml
@@ -43,6 +43,7 @@
          "app.kubernetes.io/managed-by": "Helm",
          "app.kubernetes.io/name": "release-name-podinfo",
          "app.kubernetes.io/version": "6.3.5",
+         "foo": "bar",
          "helm.sh/chart": "podinfo-6.3.5"
       },
       "name": "release-name-podinfo",
@@ -78,6 +79,7 @@
          "app.kubernetes.io/managed-by": "Helm",
          "app.kubernetes.io/name": "release-name-podinfo",
          "app.kubernetes.io/version": "6.3.5",
+         "foo": "bar",
          "helm.sh/chart": "podinfo-6.3.5"
       },
       "name": "release-name-podinfo",

--- a/releases/stagecluster/release/podinfo-helm/_namespace.yaml
+++ b/releases/stagecluster/release/podinfo-helm/_namespace.yaml
@@ -43,6 +43,7 @@
          "app.kubernetes.io/managed-by": "Helm",
          "app.kubernetes.io/name": "release-name-podinfo",
          "app.kubernetes.io/version": "6.3.5",
+         "foo": "bar",
          "helm.sh/chart": "podinfo-6.3.5"
       },
       "name": "release-name-podinfo",
@@ -78,6 +79,7 @@
          "app.kubernetes.io/managed-by": "Helm",
          "app.kubernetes.io/name": "release-name-podinfo",
          "app.kubernetes.io/version": "6.3.5",
+         "foo": "bar",
          "helm.sh/chart": "podinfo-6.3.5"
       },
       "name": "release-name-podinfo",


### PR DESCRIPTION
This way we can easily hide the "search" functionality within a native method (instead of having to convert everything to maps and back)